### PR TITLE
updated runtime test for Node.js

### DIFF
--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -28,5 +28,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: |
           npm create oak-nodejs-esbuild@latest -- -y
-          npm ci
+          npm install
           npm test


### PR DESCRIPTION
using `npm install` as opposed to `npm ci` because we install from scratch during runtime tests such as this.